### PR TITLE
Modifying prefix rule 27 to stem pen-{c|d|j|s|t|z}

### DIFF
--- a/src/Sastrawi/Morphology/Disambiguator/DisambiguatorPrefixRule27.php
+++ b/src/Sastrawi/Morphology/Disambiguator/DisambiguatorPrefixRule27.php
@@ -10,17 +10,25 @@ namespace Sastrawi\Morphology\Disambiguator;
 
 /**
  * Disambiguate Prefix Rule 27
- * Rule 27 : pen{c|d|j|z} -> pen-{c|d|j|z}
+ * 
+ * Rule 27 modified by Prasasto Adi : pen{c|d|j|s|t|z} -> pen-{c|d|j|s|t|z}
+ * in order to stem penstabilan, pentranskripsi
+ *
+ * Original CS Rule 27 was : pen{c|d|j|z} -> pen-{c|d|j|z}
  */
 class DisambiguatorPrefixRule27 implements DisambiguatorInterface
 {
     /**
      * Disambiguate Prefix Rule 27
-     * Rule 27 : pen{c|d|j|z} -> pen-{c|d|j|z}
+     * 
+     * Rule 27 modified by Prasasto Adi : pen{c|d|j|s|t|z} -> pen-{c|d|j|s|t|z}
+     * in order to stem penstabilan, pentranskripsi
+     *
+     * Original CS Rule 27 was : pen{c|d|j|z} -> pen-{c|d|j|z}
      */
     public function disambiguate($word)
     {
-        if (preg_match('/^pen([cdjz])(.*)$/', $word, $matches)) {
+        if (preg_match('/^pen([cdjstz])(.*)$/', $word, $matches)) {
             return $matches[1] . $matches[2];
         }
     }

--- a/tests/SastrawiFunctionalTest/Stemmer/StemmerTest.php
+++ b/tests/SastrawiFunctionalTest/Stemmer/StemmerTest.php
@@ -22,7 +22,9 @@ class StemmerTest extends \PHPUnit_Framework_TestCase
                 'bangun', 'fitnah', 'vonis',
                 'baru', 'ajar',
                 'tangkap', 'kupas',
-                'minum', 'pukul', 'cinta', 'dua', 'jauh', 'ziarah', 'nuklir', 'gila', 'hajar', 'qasar', 'udara',
+                'minum', 'pukul',
+                'cinta', 'dua', 'dahulu', 'jauh', 'jarah', 'ziarah',
+                'nuklir', 'nasihat', 'gila', 'hajar', 'qasar', 'udara',
                 'populer', 'warna', 'yoga', 'adil', 'rumah', 'muka', 'labuh', 'tarung',
                 'tebar', 'indah', 'daya', 'untung', 'sepuluh', 'ekonomi', 'makmur', 'telah', 'serta',
                 'percaya', 'pengaruh', 'kritik', 'seko', 'sekolah', 'tahan', 'capa', 'capai',
@@ -31,7 +33,8 @@ class StemmerTest extends \PHPUnit_Framework_TestCase
                 'sembunyi', 'langgan', 'laku', 'baik', 'terang', 'iman', 'bisik', 'taat', 'puas', 'makan',
                 'nyala', 'nyanyi', 'nyata', 'nyawa', 'rata', 'lembut', 'ligas',
                 'budaya', 'karya', 'ideal', 'final',
-                'taat', 'tiru', 'sepak', 'kuasa', 'malaikat', 'nikmat', // sastrawi additional rules
+                // sastrawi additional rules
+                'taat', 'tiru', 'sepak', 'kuasa', 'malaikat', 'nikmat', 'stabil', 'transkripsi',
                 'lewat', 'nganga', 'allah',
             )
         );
@@ -88,7 +91,8 @@ class StemmerTest extends \PHPUnit_Framework_TestCase
         $data[] = array('kesakitan', 'sakit');
         $data[] = array('sesuap', 'suap');
 
-        //$data[] = array('teriakanmu', 'teriak'); // wtf? kok jadi teria?
+        //$data[] = array('teriakanmu', 'teriak'); // wtf? kok jadi ria?
+        //teriakanmu -> te-ria-kan-mu
 
         /* template formulas for derivation prefix rules (disambiguation) */
 
@@ -138,8 +142,8 @@ class StemmerTest extends \PHPUnit_Framework_TestCase
         $data[] = array('memvonis', 'vonis');
 
         // rule 12 : mempe{r|l} -> mem-pe
-        $data[] = array('memperbaru', 'baru');
-        $data[] = array('mempelajar', 'ajar');
+        $data[] = array('memperbarui', 'baru');
+        $data[] = array('mempelajari', 'ajar');
 
         // rule 13a : mem{rV|V} -> mem{rV|V}
         $data[] = array('meminum', 'minum');
@@ -206,14 +210,13 @@ class StemmerTest extends \PHPUnit_Framework_TestCase
         $data[] = array('pemukul', 'pukul');
 
         // rule 27 : men{c|d|j|z} -> men-{c|d|j|z}
-        // TODO : should find more relevant examples
         $data[] = array('pencinta', 'cinta');
-        $data[] = array('pendua', 'dua');
-        $data[] = array('penjauh', 'jauh');
+        $data[] = array('pendahulu', 'dahulu');
+        $data[] = array('penjarah', 'jarah');
         $data[] = array('penziarah', 'ziarah');
 
         // rule 28a : pen{V} -> pe-n{V}
-        $data[] = array('penuklir', 'nuklir');
+        $data[] = array('penasihat', 'nasihat');
 
         // rule 28b : pen{V} -> pe-t{V}
         $data[] = array('penangkap', 'tangkap');
@@ -234,7 +237,7 @@ class StemmerTest extends \PHPUnit_Framework_TestCase
 
         // rule 32 : pelV -> pe-lV except pelajar -> ajar
         $data[] = array('pelajar', 'ajar');
-        $data[] = array('pelabuh', 'labuh');
+        $data[] = array('pelabuhan', 'labuh');
 
         // rule 33 : peCerV -> per-erV where C != {r|w|y|l|m|n}
         // TODO : find the examples
@@ -364,6 +367,9 @@ class StemmerTest extends \PHPUnit_Framework_TestCase
         $data[] = array('finalisasi', 'final');
 
         // sastrawi additional rules
+        $data[] = array('penstabilan', 'stabil');
+        $data[] = array('pentranskripsi', 'transkripsi');
+
         $data[] = array('mentaati', 'taat');
         $data[] = array('meniru-nirukan', 'tiru');
         $data[] = array('menyepak-nyepak', 'sepak');


### PR DESCRIPTION
Melakukan modifikasi prefix rule 27 untuk dapat mengenali kata dengan pola pen-{c|d|j|s|t|z} seperti:

- penstabilan -> pen-stabil-an
- pentranskripsi -> pen-transkripsi

Serta menambah contoh yang lebih relevant pada StemmerTest.php